### PR TITLE
Fix KtsRunner api instead of implementation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation(kotlin("scripting-compiler-embeddable"))
     implementation(kotlin("script-util"))
     implementation("net.java.dev.jna:jna:5.5.0")
-    implementation("de.swirtz:ktsRunner:0.0.7") { exclude(group = "ch.qos.logback", module = "logback-classic") }
+    api("de.swirtz:ktsRunner:0.0.7") { exclude(group = "ch.qos.logback", module = "logback-classic") }
 
     // AutoDsl Annotation
     api("com.juanchosaravia.autodsl:annotation:0.0.9")


### PR DESCRIPTION
Replace gradle dependency declaration from `implementation` to `api`
close #8 