### PR TITLE
Use function literals with receiver in the engine DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ config {
     release = false
 
     info {
+        group = "io.saagie"
         name = "Updatarium"
         description = "Automated update script management"
         inceptionYear = "2019"

--- a/engine-httpclient/src/main/kotlin/io/saagie/updatarium/dsl/action/HttpScriptAction.kt
+++ b/engine-httpclient/src/main/kotlin/io/saagie/updatarium/dsl/action/HttpScriptAction.kt
@@ -21,7 +21,7 @@ import com.autodsl.annotation.AutoDsl
 import com.github.kittinunf.fuel.core.FuelManager
 
 @AutoDsl
-class HttpScriptAction(val f: (httpScriptAction: HttpScriptAction) -> Unit) : Action() {
+class HttpScriptAction(val f: HttpScriptAction.() -> Unit) : Action() {
 
     val restClient = FuelManager.instance
 

--- a/engine-kubernetes/src/main/kotlin/io/saagie/updatarium/dsl/action/KubernetesScriptAction.kt
+++ b/engine-kubernetes/src/main/kotlin/io/saagie/updatarium/dsl/action/KubernetesScriptAction.kt
@@ -23,7 +23,7 @@ import io.saagie.updatarium.engine.kubernetes.KubernetesEngine
 @AutoDsl
 class KubernetesScriptAction(
     val namespace: String? = null,
-    val f: (kubernetesScriptAction: KubernetesScriptAction) -> Unit
+    val f: KubernetesScriptAction.() -> Unit
 ) : Action() {
 
     val client = when {

--- a/engine-mongodb/src/main/kotlin/io/saagie/updatarium/dsl/action/MongoScriptAction.kt
+++ b/engine-mongodb/src/main/kotlin/io/saagie/updatarium/dsl/action/MongoScriptAction.kt
@@ -21,7 +21,7 @@ import com.autodsl.annotation.AutoDsl
 import io.saagie.updatarium.engine.mongo.MongoEngine
 
 @AutoDsl
-class MongoScriptAction(val f: (mongoScriptAction: MongoScriptAction) -> Unit) : Action() {
+class MongoScriptAction(val f: MongoScriptAction.() -> Unit) : Action() {
 
     val mongoEngine = MongoEngine()
     val mongoClient = mongoEngine.mongoClient


### PR DESCRIPTION
function literals with receiver in the engine DSL allows to refer to the context object as a lambda receiver - by keyword this